### PR TITLE
@ pysigym : to run a next episode, env.reset() is no longer dependent on a proper terminated or truncated previous episode.

### DIFF
--- a/physigym/custom_modules/custom.cpp
+++ b/physigym/custom_modules/custom.cpp
@@ -30,13 +30,22 @@ void random_seed(void) {
 }
 
 
-void create_cell_types(void) {
+void generate_cell_types(void) {
 
     // Put any modifications to default cell definition here if you
     // want to have "inherited" by other cell types.
     // This is a good place to set default functions.
 
-    // reset cell definition for each episode (core/PhysiCell_cell.cpp).
+    // delete cells
+    for (Cell* pCell: (*all_cells)) {
+        pCell->die();
+    }
+
+    // reset cell ID counter (BioFVM/BioFVM_basic_agent.cpp)
+    // bue 20240608: not strictely necessary!
+    BioFVM::reset_max_basic_agent_ID();
+
+    // reset cell definitions (core/PhysiCell_cell.cpp)
     cell_defaults = PhysiCell::Cell_Definition();
     PhysiCell::cell_definitions_by_index.clear();
     PhysiCell::cell_definitions_by_index.push_back(&cell_defaults);

--- a/physigym/custom_modules/custom.h
+++ b/physigym/custom_modules/custom.h
@@ -18,7 +18,7 @@ using namespace PhysiCell;
 
 // setup functions to help us along
 void random_seed(void);
-void create_cell_types(void);
+void generate_cell_types(void);
 void setup_tissue(void);
 
 // set up the BioFVM microenvironment

--- a/physigym/custom_modules/embedding/physicellmodule.cpp
+++ b/physigym/custom_modules/embedding/physicellmodule.cpp
@@ -64,6 +64,9 @@ static PyObject* physicell_start(PyObject *self, PyObject *args) {
     // copy seeding file
     // nop
 
+    // reset global variables
+    PhysiCell_globals = PhysiCell_Globals();
+
     // OpenMP setup
     omp_set_num_threads(PhysiCell_settings.omp_num_threads);
 
@@ -81,7 +84,7 @@ static PyObject* physicell_start(PyObject *self, PyObject *args) {
 
     // Users typically start modifying here.
     random_seed();
-    create_cell_types();  // (re)load cell definitions; display_cell_definitions; generates rules.csv v1 file
+    generate_cell_types();  // delete cells; reload cell definitions; display_cell_definitions; generates rules.csv v1 file
     setup_tissue();
     // Users typically stop modifying here.
 
@@ -342,18 +345,6 @@ static PyObject* physicell_stop(PyObject *self, PyObject *args) {
     std::cout << "Total simulation runtime: " << std::endl;
     BioFVM::display_stopwatch_value(std::cout, BioFVM::runtime_stopwatch_value());
     std::cout << std::endl;
-
-    // delete cells
-    for (Cell* pCell: (*all_cells)) {
-        pCell->die();
-    }
-
-    // reset cell ID counter
-    // bue 20240608: not strictely necessary!
-    //BioFVM::reset_max_basic_agent_ID();
-
-    // reset global variables
-    PhysiCell_globals = PhysiCell_Globals();
 
     // go home
     return PyLong_FromLong(0);

--- a/physigym/main.cpp
+++ b/physigym/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char* argv[]) {
 
     /* Users typically start modifying here. START USERMODS */
     random_seed();
-    create_cell_types();
+    generate_cell_types();
     setup_tissue();
     /* Users typically stop modifying here. END USERMODS */
 


### PR DESCRIPTION
moved reset code from physicell.stop into physicell.start.